### PR TITLE
Update repository paths for the build process, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ You can download binary releases (for Linux and Darwin) from GitHub: [https://gi
 
 ```
 $ go get github.com/alphagov/stscreds
+$ cd $GOPATH/src/alphagov/stscreds
+$ make
 ```
+
+The resulting binary will now be at `$GOPATH/bin/stscreds`.
 
 ## Setup
 ### IAM Policy


### PR DESCRIPTION
The build was referencing the /sonofbytes/ repository, however we want this to
build directly from the /alphagov/ repository.

The docs have also been extended to include the `make` stage so it's clear how
to make use of this.